### PR TITLE
Use async for sending over websockets

### DIFF
--- a/src/main/java/org/onebusaway/gtfs_realtime/exporter/GtfsRealtimeServlet.java
+++ b/src/main/java/org/onebusaway/gtfs_realtime/exporter/GtfsRealtimeServlet.java
@@ -175,7 +175,7 @@ public class GtfsRealtimeServlet extends WebSocketServlet implements
       }
       try {
         RemoteEndpoint remote = _session.getRemote();
-        remote.sendBytes(ByteBuffer.wrap(buffer));
+        remote.sendBytesByFuture(ByteBuffer.wrap(buffer));
       } catch (Exception ex) {
         // If anything goes wrong, we close the connection.
         _log.error("error sending message to remote WebSocket client", ex);


### PR DESCRIPTION
The implementation prior can heavily suffer from the slow subscriber issue where one client can possible slow down the other clients and even the filewriter.

NOTE:
I'm not sure if this change, sending over websockets async doesn't allow for new issues such as dead sockets that will never be closed or huge backlogs on one client.
Maybe a zeromq fan-out model where each client works on it's own queue is more reliable, this would also reduce locking issues when adding new subscribers, as each client will work on a different thread.
Using a ZeroMQ poller can also implement a heartbeat which currently is not implemented yet implied by the header
