### PR TITLE
Add guava cache with a configurable timeout.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
       <version>${onebusaway_guice_jsr250_version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/onebusaway/gtfs_realtime/exporter/GtfsRealtimeExporterModule.java
+++ b/src/main/java/org/onebusaway/gtfs_realtime/exporter/GtfsRealtimeExporterModule.java
@@ -15,6 +15,7 @@
  */
 package org.onebusaway.gtfs_realtime.exporter;
 
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -109,6 +110,9 @@ public class GtfsRealtimeExporterModule extends AbstractModule {
     bind(ScheduledExecutorService.class).annotatedWith(
         Names.named(NAME_EXECUTOR)).toInstance(
         Executors.newSingleThreadScheduledExecutor());
+
+    String expire = System.getProperty("cache.expire.secs", "0");
+    bindConstant().annotatedWith(Names.named("cache.expire.secs")).to(expire);
   }
 
   /**


### PR DESCRIPTION
Add guava cache with a configurable timeout. This will allow feeds that are built incrementally to avoid growing indefinitely.

Configurable with system property `cache.expire.secs`. If this is 0 or not present, will use a normal hashmap.