### PR TITLE
fix: add missing javax.annotation dependency to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
       <artifactId>slf4j-api</artifactId>
       <version>1.7.2</version>
     </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -111,11 +110,16 @@
       <version>${onebusaway_guice_jsr250_version}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>19.0</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Hi folks,
Thank you very much for providing and maintaining this repository.

Calling ```mvn clean package``` on the ```master``` branch came back with the following reply.

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.411 s
[INFO] Finished at: 2022-09-06T12:56:16+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project onebusaway-gtfs-realtime-exporter: Compilation failure: Compilation failure: 
[ERROR] /home/begerad/git/dancesWithCycles/onebusaway-gtfs-realtime-exporter/src/main/java/org/onebusaway/gtfs_realtime/exporter/GtfsRealtimeFileWriter.java:[27,24] package javax.annotation does not exist
[ERROR] /home/begerad/git/dancesWithCycles/onebusaway-gtfs-realtime-exporter/src/main/java/org/onebusaway/gtfs_realtime/exporter/GtfsRealtimeFileWriter.java:[28,24] package javax.annotation does not exist
[ERROR] /home/begerad/git/dancesWithCycles/onebusaway-gtfs-realtime-exporter/src/main/java/org/onebusaway/gtfs_realtime/exporter/GtfsRealtimeFileWriter.java:[83,4] cannot find symbol
[ERROR]   symbol:   class PostConstruct
[ERROR]   location: class org.onebusaway.gtfs_realtime.exporter.GtfsRealtimeFileWriter
[ERROR] /home/begerad/git/dancesWithCycles/onebusaway-gtfs-realtime-exporter/src/main/java/org/onebusaway/gtfs_realtime/exporter/GtfsRealtimeFileWriter.java:[89,4] cannot find symbol
[ERROR]   symbol:   class PreDestroy
[ERROR]   location: class org.onebusaway.gtfs_realtime.exporter.GtfsRealtimeFileWriter
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
```

That is why I added this dependency. How could you run this repository in the past without this dependency in the pom.xml file?

Only this patch makes me able to get a ```BUILD SUCCESS```.

Please feel free to study, use, share or change this pull request.

Cheers!